### PR TITLE
fix: 국가별 가이드 네비 — GitBook 중첩 SUMMARY + Starlight 정합

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,7 +384,13 @@ python3 scripts/check-internal-links.py
 
 - **루트 GitBook 마크다운이 원본**입니다. 일반 도메인(`about-cloud/` … `storage/`)과 국가 가이드(`korea/`, `us/`, `eu/`, `japan/`, `singapore/`) 모두 루트에 둡니다.
 - Starlight 사이트 트리는 파생물입니다. `scripts/gitbook_to_starlight.py`로 `starlight/src/content/docs/ko/`를 재생성합니다. **`starlight/.../ko/` 직접 수정 금지.**
-- 국가 인덱스 제목/사이드바 라벨은 그룹명과 겹치지 않게 **「한국 개요」「미국 개요」**처럼 명시합니다 (`SUMMARY.md` 소제목·Starlight sidebar label).
+- **국가별 가이드 네비 (GitBook + Starlight 정합)**
+  - GitBook `SUMMARY.md`: `## 국가별 가이드` 아래에 **국가 인덱스 페이지 + 들여쓰기 하위 문서**로 둡니다.  
+    예: 상위 `- [한국](korea/index.md)`, 하위(2칸 들여쓰기) `- [CSAP](korea/security/csap.md)`.  
+    `### 한국 개요` 같은 **h3 그룹 헤딩은 쓰지 않습니다**(GitBook SUMMARY 문법 밖이라 사이드바에서 누락·평탄화될 수 있음).
+  - Starlight `astro.config.mjs`: 그룹은 페이지 링크가 될 수 없으므로 **그룹 label = 국가명**, **첫 항목 = 국가 인덱스**이고 사이드바 라벨은 **「소개」**(en: Overview, ja: 概要)로 둡니다.  
+    「한국 > 한국」「한국 개요」처럼 그룹명과 겹치거나 어색한 라벨을 피합니다.
+  - 페이지 H1(본문 제목)과 사이드바 라벨은 달라도 됩니다. GitBook은 SUMMARY 링크 텍스트, Starlight는 `label`/`translations`가 사이드바에 쓰입니다.
 
 ### 번역 티어 (권장)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -111,45 +111,31 @@
 
 ## 국가별 가이드 <a id="country-guides"></a>
 
-### 한국 개요
-
-- [한국 부록](korea/index.md)
-- [컴플라이언스 (한국)](korea/governance/compliance.md)
-- [CSAP (클라우드 보안 인증)](korea/security/csap.md)
-- [망분리와 네트워크 격리 (한국)](korea/security/network-isolation.md)
-- [소버린 FM 정책](korea/ai/sovereign-fm-policy.md)
-- [FM 제공사 비교](korea/ai/fm-providers.md)
-
-### 미국 개요
-
+- [한국](korea/index.md)
+  - [컴플라이언스 (한국)](korea/governance/compliance.md)
+  - [CSAP (클라우드 보안 인증)](korea/security/csap.md)
+  - [망분리와 네트워크 격리 (한국)](korea/security/network-isolation.md)
+  - [소버린 FM 정책](korea/ai/sovereign-fm-policy.md)
+  - [FM 제공사 비교](korea/ai/fm-providers.md)
 - [미국](us/index.md)
-- [FedRAMP](us/fedramp.md)
-- [HIPAA/HITECH](us/hipaa.md)
-- [ITAR/EAR](us/itar.md)
-- [주(州) 프라이버시법 지형](us/state-privacy.md)
-- [AI 정책과 거버넌스](us/ai-policy.md)
-
-### EU 개요
-
+  - [FedRAMP](us/fedramp.md)
+  - [HIPAA/HITECH](us/hipaa.md)
+  - [ITAR/EAR](us/itar.md)
+  - [주(州) 프라이버시법 지형](us/state-privacy.md)
+  - [AI 정책과 거버넌스](us/ai-policy.md)
 - [EU](eu/index.md)
-- [GDPR과 데이터 주권](eu/gdpr-sovereignty.md)
-- [DORA](eu/dora.md)
-- [NIS2 + EU AI Act](eu/nis2-ai-act.md)
-- [EU 회원국별 클라우드 보안 스킴](eu/national-schemes.md)
-- [유럽 소버린 AI·모델 지형](eu/sovereign-ai.md)
-
-### 일본 개요
-
+  - [GDPR과 데이터 주권](eu/gdpr-sovereignty.md)
+  - [DORA](eu/dora.md)
+  - [NIS2 + EU AI Act](eu/nis2-ai-act.md)
+  - [EU 회원국별 클라우드 보안 스킴](eu/national-schemes.md)
+  - [유럽 소버린 AI·모델 지형](eu/sovereign-ai.md)
 - [일본](japan/index.md)
-- [ISMAP](japan/ismap.md)
-- [APPI](japan/appi.md)
-- [일본 가버먼트 클라우드](japan/government-cloud.md)
-- [일본 AI 정책과 국산 모델 지형](japan/ai-landscape.md)
-
-### 싱가포르 개요
-
+  - [ISMAP](japan/ismap.md)
+  - [APPI](japan/appi.md)
+  - [일본 가버먼트 클라우드](japan/government-cloud.md)
+  - [일본 AI 정책과 국산 모델 지형](japan/ai-landscape.md)
 - [싱가포르](singapore/index.md)
-- [MTCS](singapore/mtcs.md)
-- [PDPA](singapore/pdpa.md)
-- [정부 클라우드 (GCC·IM8·SGTS)](singapore/government-cloud.md)
-- [AI 거버넌스](singapore/ai-governance.md)
+  - [MTCS](singapore/mtcs.md)
+  - [PDPA](singapore/pdpa.md)
+  - [정부 클라우드 (GCC·IM8·SGTS)](singapore/government-cloud.md)
+  - [AI 거버넌스](singapore/ai-governance.md)

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -234,6 +234,8 @@ export default defineConfig({
 					translations: { en: 'Glossary', ja: '用語集' },
 					link: 'glossary',
 				},
+				// 국가별 가이드: GitBook SUMMARY의 「국가 인덱스 + 들여쓰기 하위」에 대응.
+				// Starlight 그룹은 페이지 링크가 될 수 없으므로, 그룹명=국가명 / 첫 항목=인덱스(소개).
 				{
 					label: '국가별 가이드',
 					translations: { en: 'Country Guides', ja: '国別ガイド' },
@@ -243,7 +245,7 @@ export default defineConfig({
 							translations: { en: 'Korea', ja: '韓国' },
 							collapsed: true,
 							items: [
-								{ slug: 'korea', label: '한국 개요', translations: { en: 'Korea Overview', ja: '韓国 概要' } },
+								{ slug: 'korea', label: '소개', translations: { en: 'Overview', ja: '概要' } },
 								{ slug: 'korea/governance/compliance' },
 								{ slug: 'korea/security/csap' },
 								{ slug: 'korea/security/network-isolation' },
@@ -256,7 +258,7 @@ export default defineConfig({
 							translations: { en: 'United States', ja: '米国' },
 							collapsed: true,
 							items: [
-								{ slug: 'us', label: '미국 개요', translations: { en: 'US Overview', ja: '米国 概要' } },
+								{ slug: 'us', label: '소개', translations: { en: 'Overview', ja: '概要' } },
 								{ slug: 'us/fedramp' },
 								{ slug: 'us/hipaa' },
 								{ slug: 'us/itar' },
@@ -268,7 +270,7 @@ export default defineConfig({
 							label: 'EU',
 							collapsed: true,
 							items: [
-								{ slug: 'eu', label: 'EU 개요', translations: { en: 'EU Overview', ja: 'EU 概要' } },
+								{ slug: 'eu', label: '소개', translations: { en: 'Overview', ja: '概要' } },
 								{ slug: 'eu/gdpr-sovereignty' },
 								{ slug: 'eu/dora' },
 								{ slug: 'eu/nis2-ai-act' },
@@ -281,7 +283,7 @@ export default defineConfig({
 							translations: { en: 'Japan', ja: '日本' },
 							collapsed: true,
 							items: [
-								{ slug: 'japan', label: '일본 개요', translations: { en: 'Japan Overview', ja: '日本 概要' } },
+								{ slug: 'japan', label: '소개', translations: { en: 'Overview', ja: '概要' } },
 								{ slug: 'japan/ismap' },
 								{ slug: 'japan/appi' },
 								{ slug: 'japan/government-cloud' },
@@ -293,7 +295,7 @@ export default defineConfig({
 							translations: { en: 'Singapore', ja: 'シンガポール' },
 							collapsed: true,
 							items: [
-								{ slug: 'singapore', label: '싱가포르 개요', translations: { en: 'Singapore Overview', ja: 'シンガポール 概要' } },
+								{ slug: 'singapore', label: '소개', translations: { en: 'Overview', ja: '概要' } },
 								{ slug: 'singapore/mtcs' },
 								{ slug: 'singapore/pdpa' },
 								{ slug: 'singapore/government-cloud' },


### PR DESCRIPTION
## Summary

GitBook 사이드바에서 국가별 가이드가 제대로 안 보이거나 계층이 깨질 수 있는 원인을 고칩니다.

- **원인**: `SUMMARY.md` 국가 섹션이 `### 한국 개요` 같은 **h3 그룹 헤딩**을 쓰고 있었는데, GitBook 공식 SUMMARY 문법은 `##` 그룹 + (필요 시) **들여쓰기 하위 페이지**만 문서화되어 있습니다.
- **GitBook (옵션 A)**: `## 국가별 가이드` 아래에 국가 인덱스를 상위 페이지로 두고, 상세 문서를 2칸 들여쓰기 하위로 둡니다.
  - 예: `한국` → CSAP / 망분리 / …
- **Starlight**: 그룹 객체는 페이지 링크가 될 수 없어, **그룹 label = 국가명**, **첫 항목 = 국가 인덱스(라벨: 소개 / Overview / 概要)** 로 같은 계층을 표현합니다. 어색한 「한국 개요」 라벨은 제거합니다.
- **CONTRIBUTING**: 위 규칙을 SOT/네비 정합 가이드로 명문화합니다.

## 변경 파일

- `SUMMARY.md`
- `starlight/astro.config.mjs`
- `CONTRIBUTING.md`

## Test plan

- [x] `python3 scripts/check-internal-links.py` 통과 (국가 28편 모두 SUMMARY 포함)
- [x] `markdownlint-cli2` on `SUMMARY.md`, `CONTRIBUTING.md` 통과
- [ ] GitBook Git Sync 후 사이드바에 `국가별 가이드 → 한국 → CSAP …` 계층 표시 확인
- [ ] Starlight dev/build 사이드바에서 `국가별 가이드 → 한국 → 소개 / …` 확인
- [ ] 각 국가 인덱스·하위 페이지 링크 클릭 동작 확인